### PR TITLE
Add AI Badgr as optional OpenAI-compatible backend

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -198,6 +198,7 @@ def safe_request():
 ### **Supported Providers**  
 | Provider       | Auth Type       | Example Models       |  
 |----------------|-----------------|----------------------|  
+| AIBadgr        | API Key         | `gpt-4o-mini`        |  
 | Anthropic      | API Key         | `claude-3.5-sonnet`  |  
 | Gemini         | Cookies         | `gemini-1.5-pro`     |  
 | Groq           | API Key         | `mixtral-8x7b`       |  

--- a/docs/config.md
+++ b/docs/config.md
@@ -10,6 +10,7 @@ Authentication, API Keys, Cookies, `.har` files, Debug Mode, Proxy Setup, and GU
 Create a `.env` file in your cookies/config directory:
 
 ```env
+AIBADGR_API_KEY=
 HUGGINGFACE_API_KEY=
 POLLINATIONS_API_KEY=
 GEMINI_API_KEY=

--- a/docs/providers/aibadgr.md
+++ b/docs/providers/aibadgr.md
@@ -1,0 +1,141 @@
+# AI Badgr
+
+AI Badgr is an OpenAI-compatible API provider that can be used with gpt4free (g4f).
+
+## Requirements
+
+- **API Key**: Required (get free key from [AI Badgr Contact](https://aibadgr.com/#contact))
+- **Authentication**: Bearer token
+
+## API Routes
+
+| Type | URL |
+|------|-----|
+| BaseURL | `https://aibadgr.com/api/v1` |
+
+## Features
+
+- ✅ Chat completions
+- ✅ Streaming responses
+- ✅ System messages
+- ✅ Message history
+- ✅ OpenAI-compatible API
+
+## Getting Started
+
+### 1. Get Your API Key
+
+Visit https://aibadgr.com/#contact to request a free API key.
+
+### 2. Install gpt4free
+
+```bash
+pip install -U g4f[all]
+```
+
+### 3. Use AI Badgr with g4f
+
+#### Python Example
+
+```python
+from g4f.client import Client
+from g4f.Provider import AIBadgr
+
+# Create client with AI Badgr provider
+client = Client(
+    provider=AIBadgr,
+    api_key="your-api-key-here"
+)
+
+# Chat completion
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.choices[0].message.content)
+```
+
+#### Using Environment Variables
+
+```bash
+export AIBADGR_API_KEY="your-api-key-here"
+```
+
+```python
+from g4f.client import Client
+from g4f.Provider import AIBadgr
+
+# API key will be loaded from environment variable
+client = Client(provider=AIBadgr)
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.choices[0].message.content)
+```
+
+#### Streaming Responses
+
+```python
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True
+)
+
+for chunk in response:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+```
+
+#### cURL Example
+
+```bash
+curl https://aibadgr.com/api/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+## Using with Standard OpenAI Client
+
+Since AI Badgr is OpenAI-compatible, you can use it with the standard OpenAI Python client by changing the base URL:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your-aibadgr-api-key",
+    base_url="https://aibadgr.com/api/v1"
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.choices[0].message.content)
+```
+
+## Supported Models
+
+AI Badgr supports OpenAI-compatible models. Check the [AI Badgr documentation](https://aibadgr.com) for the latest list of available models.
+
+## Configuration Options
+
+| Option | Description | Required |
+|--------|-------------|----------|
+| `api_key` | Your AI Badgr API key | Yes |
+| `api_base` | API base URL (default: https://aibadgr.com/api/v1) | No |
+| `model` | Model to use | Yes |
+| `stream` | Enable streaming responses | No |
+| `temperature` | Sampling temperature | No |
+| `max_tokens` | Maximum tokens to generate | No |
+
+## Support
+
+- Website: https://aibadgr.com
+- Contact: https://aibadgr.com/#contact

--- a/docs/ready_to_use.md
+++ b/docs/ready_to_use.md
@@ -28,6 +28,7 @@
 - **Strinable Inf**: https://stringableinf.com/api/v1
 - **TypeGPT**: https://typegpt.ai/api
 - **Grok**: https://api.grok.com/v1
+- **AI Badgr**: https://aibadgr.com/api/v1
 - **ApiAirforce**: baseUrl: https://api.airforce/v1, apiEndpoint: https://stringableinf.com/api/v1/chat/completions
 - **Auto Provider & Model Selection**: apiEndpoint: https://g4f.dev/ai/{now}
 


### PR DESCRIPTION
This PR adds documentation for using AI Badgr as an optional OpenAI-compatible backend.

### What’s changed
- Adds a short docs section explaining how to point existing OpenAI-style config to AI Badgr
- Shows how to set:
  - `base_url = https://aibadgr.com/api/v1`
  - `api_key` = AI Badgr API key
- Includes minimal examples (Python / JavaScript / cURL)

### Notes
- Docs-only change – no code or behavior changes
- Optional provider – nothing in the project depends on AI Badgr
- Follows the same pattern as other provider docs in this repo

Contributor License Agreement: I agree to the contributor license agreement terms for this repository.